### PR TITLE
Update release-drafter.yml to exclude 'renovate'

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -56,6 +56,9 @@ categories:
   - type: "version-resolver"
     semver-increment: patch
 
+exclude-contributors:
+  - "renovate"
+
 template: |
   ## What’s changed
 


### PR DESCRIPTION
Exclude 'renovate' from contributors in release drafter.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
